### PR TITLE
core/write_s3: Log write errors in ERROR logging level

### DIFF
--- a/core/write_s3.go
+++ b/core/write_s3.go
@@ -47,9 +47,13 @@ func (s *writeS3) Write(dirname, filename, content, contentType, contentEncoding
 		Metadata:        metadata,
 	})
 
-	logging.GetLogger().Infof("Write %s result: %v", filename, err)
+	if err != nil {
+		logging.GetLogger().Errorf("During Write %s error: %v", filename, err)
+		return err
+	}
 
-	return err
+	logging.GetLogger().Infof("Wrote %s", filename)
+	return nil
 }
 
 // NewWriteS3 creates a new S3-compatible object storage client


### PR DESCRIPTION
Before this fix, errors in writing objects to S3/COS were logged in INFO level.

This fix makes the exporter log errors in ERROR level and successful writes in INFO level.