### PR TITLE
fixed function names in accountNone object

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -29,11 +29,11 @@ type accountNone struct {
 }
 
 // Reset counters
-func (a *accountNone) Cleanup() {
+func (a *accountNone) Reset() {
 }
 
 // Add to counters
-func (a *accountNone) Account(bytes int64) {
+func (a *accountNone) Add(bytes int64) {
 }
 
 // NewAccountNone create a new accounter


### PR DESCRIPTION

The Accounter interface in pipeline.go is defined to be:
type Accounter interface {
        Reset()
        Add(bytes int64)
}

but the corresponding function names in account.go were different. We changed them from Cleanup/Account to Reset/Add.