### PR TITLE
fixed path names of imports to new directory structure

### DIFF
--- a/secadvisor/main.go
+++ b/secadvisor/main.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	secadvisor "github.com/skydive-project/skydive-flow-exporter/secadvisor/pkg"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 )
 
 func main() {

--- a/secadvisor/pkg/encode.go
+++ b/secadvisor/pkg/encode.go
@@ -20,7 +20,7 @@ package mod
 import (
 	"github.com/spf13/viper"
 
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 )
 
 type encode struct {

--- a/secadvisor/pkg/encode_test.go
+++ b/secadvisor/pkg/encode_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 )
 
 func areEqualJSON(buf1, buf2 []byte) (bool, error) {

--- a/secadvisor/pkg/mangle_logstatus.go
+++ b/secadvisor/pkg/mangle_logstatus.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/skydive-project/skydive/common"
-	awsflowlogs "github.com/skydive-project/skydive/contrib/exporters/awsflowlogs/mod"
+	awsflowlogs "github.com/skydive-project/skydive-flow-exporter/awsflowlogs/pkg"
 )
 
 type mangleLogStatus struct {

--- a/secadvisor/pkg/mangle_logstatus_test.go
+++ b/secadvisor/pkg/mangle_logstatus_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	awsflowlogs "github.com/skydive-project/skydive/contrib/exporters/awsflowlogs/mod"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	awsflowlogs "github.com/skydive-project/skydive-flow-exporter/awsflowlogs/pkg"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	"github.com/skydive-project/skydive/flow"
 )
 

--- a/secadvisor/pkg/resolve_docker.go
+++ b/secadvisor/pkg/resolve_docker.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/skydive-project/skydive/api/client"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	g "github.com/skydive-project/skydive/gremlin"
 )
 

--- a/secadvisor/pkg/resolve_runc.go
+++ b/secadvisor/pkg/resolve_runc.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/skydive-project/skydive/api/client"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	"github.com/skydive-project/skydive/graffiti/graph"
 	g "github.com/skydive-project/skydive/gremlin"
 )

--- a/secadvisor/pkg/resolve_vm.go
+++ b/secadvisor/pkg/resolve_vm.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/skydive-project/skydive/api/client"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	g "github.com/skydive-project/skydive/gremlin"
 )
 

--- a/secadvisor/pkg/transform.go
+++ b/secadvisor/pkg/transform.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	"github.com/skydive-project/skydive/flow"
 )
 

--- a/secadvisor/pkg/transform_test.go
+++ b/secadvisor/pkg/transform_test.go
@@ -26,7 +26,7 @@ import (
 	cache "github.com/pmylund/go-cache"
 
 	"github.com/skydive-project/skydive/common"
-	"github.com/skydive-project/skydive/contrib/exporters/core"
+	"github.com/skydive-project/skydive-flow-exporter/core"
 	"github.com/skydive-project/skydive/flow"
 )
 


### PR DESCRIPTION

Updated path names of imports from github.com/skydive-project/skydive/contrib/exporters to github.com/skydive-project/skydive-flow-exporter to reflect the new directory structure.