### PR TITLE
core/Makefile: Add dummy clean target

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -21,3 +21,6 @@ all:
 .PHONY: fmt
 fmt:
 	gofmt -w -s *.go
+
+.PHONY: clean
+clean:


### PR DESCRIPTION
Add a `clean` target to the `core` subfolder, so the root `make clean`
won't fail.