### PR TITLE
secadvisor: add Context element to transformed flows

### DIFF
--- a/secadvisor/pkg/gremlin_queries.go
+++ b/secadvisor/pkg/gremlin_queries.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package mod
+
+import (
+	"github.com/skydive-project/skydive/graffiti/graph"
+	g "github.com/skydive-project/skydive/gremlin"
+)
+
+func queryNodeType(gremlinClient GremlinNodeGetter, nodeTID string) (string, error) {
+	node, err := gremlinClient.GetNode(g.G.V().Has("TID", nodeTID))
+	if err != nil {
+		return "", err
+	}
+
+	return node.GetFieldString("Type")
+}
+
+func queryPodByContainerID(gremlinClient GremlinNodeGetter,
+	containerIDPrefix, containerID string) (*PeerContext, error) {
+	containerIDValue := containerIDPrefix + "://" + containerID
+	node, err := gremlinClient.GetNode(g.G.V().Has("K8s.Extra.Status.ContainerStatuses.ContainerID", containerIDValue))
+	if err != nil {
+		return nil, err
+	}
+
+	namespace, err := node.GetFieldString("K8s.Namespace")
+	if err != nil {
+		return nil, err
+	}
+	podName, err := node.GetFieldString("K8s.Name")
+	if err != nil {
+		return nil, err
+	}
+	name := namespace + "/" + podName
+
+	set := extractSet(node, namespace)
+
+	return &PeerContext{
+		Type: PeerTypePod,
+		Name: name,
+		Set:  set,
+	}, nil
+}
+
+func extractSet(node *graph.Node, namespace string) string {
+	ownerRefs, err := node.GetField("K8s.Extra.ObjectMeta.OwnerReferences")
+	if err != nil {
+		return ""
+	}
+	ownerRefsList, ok := ownerRefs.([]interface{})
+	if !ok || len(ownerRefsList) < 1 {
+		return ""
+	}
+	ownerRef, ok := ownerRefsList[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	// kind can be "ReplicaSet" or "DaemonSet"
+	kind, ok := ownerRef["Kind"].(string)
+	if !ok {
+		return ""
+	}
+	name, ok := ownerRef["Name"].(string)
+	if !ok {
+		return ""
+	}
+	return kind + ":" + namespace + "/" + name
+}

--- a/secadvisor/pkg/resolve_docker_test.go
+++ b/secadvisor/pkg/resolve_docker_test.go
@@ -1,6 +1,7 @@
 package mod
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,32 +9,39 @@ func newTestResolveDocker(t *testing.T) Resolver {
 	return &resolveDocker{gremlinClient: newLocalGremlinQueryHelper(newDockerTopologyGraph(t))}
 }
 
-func TestResolveDockerShouldFindContainerNameWithMultipleNetworkInterfaces(t *testing.T) {
+func newTestResolveKubernetesOnDocker(t *testing.T) Resolver {
+	return &resolveDocker{gremlinClient: newLocalGremlinQueryHelper(newKubernetesOnDockerTopologyGraph(t))}
+}
+
+func TestResolveDockerShouldFindContainerContext(t *testing.T) {
 	r := newTestResolveDocker(t)
-	expected := "0_0_pinger-container-1_0"
+	expected := &PeerContext{
+		Type: "container",
+		Name: "pinger-container-1",
+	}
 	nameTIDs := []string{
 		"eac0f98c-2ab0-5b89-6490-9e8816f8cba3", // eth0 interface inside the container netns
 		"38e2f253-2305-5e91-5af5-2bfcab208b1a", // veth interface
 		"577f878a-1e7f-5b2d-60f0-efc7ff5da510", // docker0 bridge
 	}
 	for _, nameTID := range nameTIDs {
-		actual, err := r.IPToName("172.17.0.3", nameTID)
+		actual, err := r.IPToContext("172.17.0.3", nameTID)
 		if err != nil {
-			t.Fatalf("IPToName failed: %v", err)
+			t.Fatalf("IPToContext (nameTID=%s) failed: %v", nameTID, err)
 		}
-		if actual != expected {
-			t.Errorf("Expected: %v, got: %v", expected, actual)
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Expected: %+v, got: %+v", expected, actual)
 		}
 	}
 }
 
-func TestResolveDockerShouldNotFindNameOfNonExistingIP(t *testing.T) {
+func TestResolveDockerShouldNotFindContextOfNonExistingIP(t *testing.T) {
 	r := newTestResolveDocker(t)
-	actual, err := r.IPToName("8.7.6.5", "eac0f98c-2ab0-5b89-6490-9e8816f8cba3")
+	actual, err := r.IPToContext("8.7.6.5", "eac0f98c-2ab0-5b89-6490-9e8816f8cba3")
 	if err == nil {
 		t.Errorf("Expected error but got none")
 	}
-	if actual != "" {
+	if actual != nil {
 		t.Errorf("Expected empty response, got: %v", actual)
 	}
 }
@@ -58,5 +66,21 @@ func TestResolveDockerShouldNotFindTIDTypeOfNonExistingTID(t *testing.T) {
 	}
 	if actual != "" {
 		t.Errorf("Expected empty response, got: %v", actual)
+	}
+}
+
+func TestResolveKubernetesOnDockerShouldFindPodInfo(t *testing.T) {
+	r := newTestResolveKubernetesOnDocker(t)
+	expected := &PeerContext{
+		Type: "pod",
+		Name: "default/pinger-depl-867fbd4567-8fdwd",
+		Set:  "ReplicaSet:default/pinger-depl-867fbd4567",
+	}
+	actual, err := r.IPToContext("172.17.0.5", "460e53ed-2cc4-5116-69b0-f5fe754a31b2")
+	if err != nil {
+		t.Fatalf("IPToContext failed: %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %+v, got: %+v", expected, actual)
 	}
 }

--- a/secadvisor/pkg/resolve_fallback.go
+++ b/secadvisor/pkg/resolve_fallback.go
@@ -36,7 +36,7 @@ func (rc *resolveFallback) IPToName(ipString, nodeTID string) (string, error) {
 
 	name, err := rc.resolver.IPToName(ipString, nodeTID)
 	if err != nil {
-		return ipString, nil
+		return "", nil
 	}
 
 	return name, nil

--- a/secadvisor/pkg/resolve_fallback.go
+++ b/secadvisor/pkg/resolve_fallback.go
@@ -28,18 +28,18 @@ func NewResolveFallback(resolver Resolver) Resolver {
 	}
 }
 
-// IPToName resolve ip address to name
-func (rc *resolveFallback) IPToName(ipString, nodeTID string) (string, error) {
+// IPToContext resolves IP address to Peer context
+func (rc *resolveFallback) IPToContext(ipString, nodeTID string) (*PeerContext, error) {
 	if ipString == "" {
-		return "", nil
+		return nil, nil
 	}
 
-	name, err := rc.resolver.IPToName(ipString, nodeTID)
+	context, err := rc.resolver.IPToContext(ipString, nodeTID)
 	if err != nil {
-		return "", nil
+		return nil, nil
 	}
 
-	return name, nil
+	return context, nil
 }
 
 // TIDToType resolve tid to type

--- a/secadvisor/pkg/resolve_multi.go
+++ b/secadvisor/pkg/resolve_multi.go
@@ -32,15 +32,15 @@ func NewResolveMulti(resolvers ...Resolver) Resolver {
 	}
 }
 
-// IPToName resolve ip address to name
-func (rm *resolveMulti) IPToName(ipString, nodeTID string) (string, error) {
+// IPToContext resolves IP address to Peer context
+func (rm *resolveMulti) IPToContext(ipString, nodeTID string) (*PeerContext, error) {
 	for _, r := range rm.resolvers {
-		if name, err := r.IPToName(ipString, nodeTID); err == nil {
-			return name, nil
+		if context, err := r.IPToContext(ipString, nodeTID); err == nil {
+			return context, nil
 		}
 	}
 
-	return "", common.ErrNotFound
+	return nil, common.ErrNotFound
 }
 
 // TIDToType resolve tid to type

--- a/secadvisor/pkg/resolve_runc.go
+++ b/secadvisor/pkg/resolve_runc.go
@@ -47,7 +47,7 @@ type resolveRunc struct {
 
 // IPToContext resolves IP address to Peer context
 func (r *resolveRunc) IPToContext(ipString, nodeTID string) (*PeerContext, error) {
-	node, err := r.gremlinClient.GetNode(g.G.V().Has("TID", nodeTID).Out("Runc.Hosts.IP", ipString))
+	node, err := r.gremlinClient.GetNode(g.G.V().Has("Runc.Hosts.IP", ipString).ShortestPathTo(g.Metadata("TID", nodeTID)))
 	if err != nil {
 		return nil, err
 	}

--- a/secadvisor/pkg/resolve_runc.go
+++ b/secadvisor/pkg/resolve_runc.go
@@ -45,27 +45,36 @@ type resolveRunc struct {
 	gremlinClient GremlinNodeGetter
 }
 
-// IPToName resolve ip to name
-func (r *resolveRunc) IPToName(ipString, nodeTID string) (string, error) {
+// IPToContext resolves IP address to Peer context
+func (r *resolveRunc) IPToContext(ipString, nodeTID string) (*PeerContext, error) {
 	node, err := r.gremlinClient.GetNode(g.G.V().Has("TID", nodeTID).Out("Runc.Hosts.IP", ipString))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	name, err := node.GetFieldString("Runc.Hosts.Hostname")
 	if err != nil {
-		return "", err
+		name = ""
 	}
 
-	return "0_0_" + name + "_0", nil
+	containerID, err := node.GetFieldString("Runc.ContainerID")
+	if err != nil {
+		containerID = ""
+	}
+
+	podPeerContext, err := queryPodByContainerID(r.gremlinClient, "containerd", containerID)
+	if err != nil {
+		// No pod information
+		return &PeerContext{
+			Type: PeerTypeContainer,
+			Name: name,
+		}, nil
+	}
+
+	return podPeerContext, nil
 }
 
 // TIDToType resolve tid to type
 func (r *resolveRunc) TIDToType(nodeTID string) (string, error) {
-	node, err := r.gremlinClient.GetNode(g.G.V().Has("TID", nodeTID))
-	if err != nil {
-		return "", err
-	}
-
-	return node.GetFieldString("Type")
+	return queryNodeType(r.gremlinClient, nodeTID)
 }

--- a/secadvisor/pkg/resolve_runc_test.go
+++ b/secadvisor/pkg/resolve_runc_test.go
@@ -1,6 +1,7 @@
 package mod
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -8,25 +9,28 @@ func newTestResolveRunc(t *testing.T) Resolver {
 	return &resolveRunc{gremlinClient: newLocalGremlinQueryHelper(newRuncTopologyGraph(t))}
 }
 
-func TestResolveRuncShouldFindContainerName(t *testing.T) {
+func TestResolveRuncShouldFindContainerContext(t *testing.T) {
 	r := newTestResolveRunc(t)
-	expected := "0_0_my-container-name-5bbc557665-h66vq_0"
-	actual, err := r.IPToName("172.30.149.34", "ce2ed4fb-1340-57b1-796f-5d648665aed7")
-	if err != nil {
-		t.Fatalf("IPToName failed: %v", err)
+	expected := &PeerContext{
+		Type: "container",
+		Name: "my-container-name-5bbc557665-h66vq",
 	}
-	if actual != expected {
-		t.Errorf("Expected: %v, got: %v", expected, actual)
+	actual, err := r.IPToContext("172.30.149.34", "ce2ed4fb-1340-57b1-796f-5d648665aed7")
+	if err != nil {
+		t.Fatalf("IPToContext failed: %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %+v, got: %+v", expected, actual)
 	}
 }
 
-func TestResolveRuncShouldNotFindNameOfNonExistingIP(t *testing.T) {
+func TestResolveRuncShouldNotFindContextOfNonExistingIP(t *testing.T) {
 	r := newTestResolveRunc(t)
-	actual, err := r.IPToName("11.22.33.44", "ce2ed4fb-1340-57b1-796f-5d648665aed7")
+	actual, err := r.IPToContext("11.22.33.44", "ce2ed4fb-1340-57b1-796f-5d648665aed7")
 	if err == nil {
 		t.Errorf("Expected error but got none")
 	}
-	if actual != "" {
+	if actual != nil {
 		t.Errorf("Expected empty response, got: %v", actual)
 	}
 }

--- a/secadvisor/pkg/resolve_vm_test.go
+++ b/secadvisor/pkg/resolve_vm_test.go
@@ -1,0 +1,59 @@
+package mod
+
+import (
+	"reflect"
+	"testing"
+)
+
+func newTestResolveVM(t *testing.T) Resolver {
+	return &resolveVM{gremlinClient: newLocalGremlinQueryHelper(newVMTopologyGraph(t))}
+}
+
+func TestResolveVMShouldFindHostContext(t *testing.T) {
+	r := newTestResolveVM(t)
+	expected := &PeerContext{
+		Type: "host",
+		Name: "my-host-name-1",
+	}
+	actual, err := r.IPToContext("100.101.102.103", "09dcdca2-4259-5df9-47fc-e4bed4eac0ed")
+	if err != nil {
+		t.Fatalf("IPToContext failed: %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %+v, got: %+v", expected, actual)
+	}
+}
+
+func TestResolveVMShouldNotFindContextOfNonExistingIP(t *testing.T) {
+	r := newTestResolveVM(t)
+	actual, err := r.IPToContext("11.22.33.44", "09dcdca2-4259-5df9-47fc-e4bed4eac0ed")
+	if err == nil {
+		t.Errorf("Expected error but got none")
+	}
+	if actual != nil {
+		t.Errorf("Expected empty response, got: %v", actual)
+	}
+}
+
+func TestResolveVMShouldFindTIDType(t *testing.T) {
+	r := newTestResolveVM(t)
+	expected := "device"
+	actual, err := r.TIDToType("09dcdca2-4259-5df9-47fc-e4bed4eac0ed")
+	if err != nil {
+		t.Fatalf("TIDToType failed: %v", err)
+	}
+	if actual != expected {
+		t.Errorf("Expected: %v, got: %v", expected, actual)
+	}
+}
+
+func TestResolveVMShouldNotFindTIDTypeOfNonExistingTID(t *testing.T) {
+	r := newTestResolveVM(t)
+	actual, err := r.TIDToType("11111111-1111-1111-1111-111111111111")
+	if err == nil {
+		t.Error("Expected error but got none")
+	}
+	if actual != "" {
+		t.Errorf("Expected empty response, got: %v", actual)
+	}
+}

--- a/secadvisor/pkg/resolvers_test.go
+++ b/secadvisor/pkg/resolvers_test.go
@@ -18,6 +18,7 @@
 package mod
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -53,7 +54,16 @@ func (l *localGremlinQueryHelper) GetNodes(query interface{}) ([]*graph.Node, er
 	}
 	nodes := make([]*graph.Node, 0, len(result))
 	for _, item := range result {
-		nodes = append(nodes, item.(*graph.Node))
+		switch item.(type) {
+		case *graph.Node:
+			nodes = append(nodes, item.(*graph.Node))
+		case []*graph.Node:
+			for _, i := range item.([]*graph.Node) {
+				nodes = append(nodes, i)
+			}
+		default:
+			return nil, fmt.Errorf("Unknown type %T of item", item.(type))
+		}
 	}
 	return nodes, nil
 }

--- a/secadvisor/pkg/resolvers_test.go
+++ b/secadvisor/pkg/resolvers_test.go
@@ -51,7 +51,7 @@ func (l *localGremlinQueryHelper) GetNodes(query interface{}) ([]*graph.Node, er
 	if err != nil {
 		return nil, err
 	}
-	var nodes []*graph.Node
+	nodes := make([]*graph.Node, 0, len(result))
 	for _, item := range result {
 		nodes = append(nodes, item.(*graph.Node))
 	}
@@ -174,5 +174,149 @@ func newDockerTopologyGraph(t *testing.T) *graph.Graph {
 	g.Link(netnsNode, dockereth0Node, graph.Metadata{})
 	g.Link(netnsNode, containerNode, graph.Metadata{})
 
+	return g
+}
+
+func newKubernetesOnRuncTopologyGraph(t *testing.T) *graph.Graph {
+	g := newGraph(t)
+
+	netnsNode, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "netns",
+		"Manager": "runc",
+		"Name":    "3709cd6138c28d5b56ed85d8aa05de7db40ba729c09e1df96c99d4e0d4cb0203",
+		"Runtime": "runc",
+		"TID":     "c3687053-ba82-5ccc-4c43-73a297f55f47",
+	})
+	containerNode, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "container",
+		"Runtime": "runc",
+		"Manager": "runc",
+		"Name":    "8a32bc39ff9c6d8555fdc0fa3af7b61c14fd7ccd3865193a8b07ce7087ec106b",
+		"Runc": map[string]interface{}{
+			"ContainerID": "8a32bc39ff9c6d8555fdc0fa3af7b61c14fd7ccd3865193a8b07ce7087ec106b",
+			"Hosts": map[string]interface{}{
+				"IP":       "172.30.60.108",
+				"Hostname": "kubernetes-dashboard-7996b848f4-pmv4z",
+			},
+		},
+		"TID": "7763a2ac-77ea-5e8f-475d-3de12b6c740d",
+	})
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "pod",
+		"Manager": "k8s",
+		"Name":    "kubernetes-dashboard-7996b848f4-pmv4z",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"ObjectMeta": map[string]interface{}{
+					"OwnerReferences": []interface{}{
+						map[string]interface{}{
+							"Kind": "ReplicaSet",
+							"Name": "kubernetes-dashboard-7996b848f4",
+						},
+					},
+				},
+				"Status": map[string]interface{}{
+					"ContainerStatuses": []interface{}{
+						map[string]interface{}{
+							"ContainerID": "containerd://8a32bc39ff9c6d8555fdc0fa3af7b61c14fd7ccd3865193a8b07ce7087ec106b",
+						},
+					},
+				},
+			},
+			"IP":        "172.30.60.108",
+			"Name":      "kubernetes-dashboard-7996b848f4-pmv4z",
+			"Namespace": "kube-system",
+		},
+	})
+
+	g.Link(netnsNode, containerNode, graph.Metadata{})
+
+	return g
+}
+
+func newKubernetesOnDockerTopologyGraph(t *testing.T) *graph.Graph {
+	g := newGraph(t)
+
+	dockereth0Node, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type": "veth",
+		"IPV4": []string{"172.17.0.5/16"},
+		"Name": "eth0",
+		"TID":  "460e53ed-2cc4-5116-69b0-f5fe754a31b2",
+	})
+	netnsNode, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "netns",
+		"Manager": "docker",
+		"Name":    "k8s_pinger-two_pinger-depl-867fbd4567-8fdwd_default_38b64484-ddd2-11e9-9c32-06615272ae54_0",
+		"TID":     "d4e62829-bfe5-5a0d-5676-8459f8428ac4",
+	})
+	containerNode, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "container",
+		"Name":    "k8s_pinger-two_pinger-depl-867fbd4567-8fdwd_default_38b64484-ddd2-11e9-9c32-06615272ae54_0",
+		"Manager": "docker",
+		"Docker": map[string]interface{}{
+			"ContainerID":   "c8be05f0616091df905d8aa409431ae4061e9af2881c6bc6ee3abb19b7aa1eb9",
+			"ContainerName": "k8s_pinger-two_pinger-depl-867fbd4567-8fdwd_default_38b64484-ddd2-11e9-9c32-06615272ae54_0",
+		},
+		"TID": "1062e3fa-927f-55bb-4b9d-b22be94fd22b",
+	})
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Type":    "pod",
+		"Manager": "k8s",
+		"Name":    "pinger-depl-867fbd4567-8fdwd",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"ObjectMeta": map[string]interface{}{
+					"OwnerReferences": []interface{}{
+						map[string]interface{}{
+							"Kind": "ReplicaSet",
+							"Name": "pinger-depl-867fbd4567",
+						},
+					},
+				},
+				"Status": map[string]interface{}{
+					"ContainerStatuses": []interface{}{
+						map[string]interface{}{
+							"ContainerID": "docker://28ee7186dc2ff973337680cdd16d987f010e34d56e236e70a465481b6693e05e",
+						},
+						map[string]interface{}{
+							"ContainerID": "docker://c8be05f0616091df905d8aa409431ae4061e9af2881c6bc6ee3abb19b7aa1eb9",
+						},
+					},
+				},
+			},
+			"IP":        "172.17.0.5",
+			"Name":      "pinger-depl-867fbd4567-8fdwd",
+			"Namespace": "default",
+		},
+	})
+
+	g.Link(netnsNode, dockereth0Node, graph.Metadata{})
+	g.Link(netnsNode, containerNode, graph.Metadata{})
+
+	return g
+}
+
+func newVMTopologyGraph(t *testing.T) *graph.Graph {
+	g := newGraph(t)
+	hostNode, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type": "host",
+		"Name": "my-host-name-1",
+		"TID":  "3ac60fae-bf77-5a60-548f-21d5663ffdeb",
+	})
+	eth0Node, _ := g.NewNode(graph.GenID(), graph.Metadata{
+		"Type": "device",
+		"TID":  "09dcdca2-4259-5df9-47fc-e4bed4eac0ed",
+		"RoutingTables": []interface{}{
+			map[string]interface{}{
+				"ID":  254,
+				"Src": nil,
+			},
+			map[string]interface{}{
+				"ID":  254,
+				"Src": "100.101.102.103",
+			},
+		},
+	})
+	g.Link(hostNode, eth0Node, graph.Metadata{})
 	return g
 }

--- a/secadvisor/pkg/transform.go
+++ b/secadvisor/pkg/transform.go
@@ -47,7 +47,7 @@ func NewTransform(cfg *viper.Viper) (interface{}, error) {
 	}, nil
 }
 
-const version = "1.0.8"
+const version = "1.1.0"
 
 // SecurityAdvisorFlowLayer is the flow layer for a security advisor flow
 type SecurityAdvisorFlowLayer struct {

--- a/secadvisor/pkg/transform.go
+++ b/secadvisor/pkg/transform.go
@@ -58,24 +58,54 @@ type SecurityAdvisorFlowLayer struct {
 	BName    string `json:"B_Name,omitempty"`
 }
 
+type PeerType string
+
+const (
+	// Peer is recognized as a Kubernetes pod
+	PeerTypePod PeerType = "pod"
+	// Peer is recognized as a Docker or Runc container but couldn't be associated to a pod
+	PeerTypeContainer PeerType = "container"
+	// Peer is recognized as a host
+	PeerTypeHost PeerType = "host"
+)
+
+// PeerContext holds information about a peer, such as conatiner or pod info
+type PeerContext struct {
+	// Type of peer (see PeerType)
+	Type PeerType `json:"Type,omitempty"`
+	// Name of the peer (for example: "namespace/pod-name")
+	Name string `json:"Name,omitempty"`
+	// Optional. Name of the set that owns this peer (for example:
+	// "ReplicaSet:namespace/replicaset-name")
+	Set string `json:"Set,omitempty"`
+}
+
+// SecurityAdvisorPeerContexts holds the optional context structures for the
+// two peers of the flow
+type SecurityAdvisorPeerContexts struct {
+	A *PeerContext `json:"A,omitempty"`
+	B *PeerContext `json:"B,omitempty"`
+}
+
 // SecurityAdvisorFlow represents a security advisor flow
 type SecurityAdvisorFlow struct {
-	UUID             string                    `json:"UUID,omitempty"`
-	LinkID           int64                     `json:"-"`
-	L3TrackingID     string                    `json:"-"`
-	LayersPath       string                    `json:"LayersPath,omitempty"`
-	Version          string                    `json:"Version,omitempty"`
-	Status           string                    `json:"Status,omitempty"`
-	FinishType       string                    `json:"FinishType,omitempty"`
-	Network          *SecurityAdvisorFlowLayer `json:"Network,omitempty"`
-	Transport        *SecurityAdvisorFlowLayer `json:"Transport,omitempty"`
-	LastUpdateMetric *flow.FlowMetric          `json:"LastUpdateMetric,omitempty"`
-	Metric           *flow.FlowMetric          `json:"Metric,omitempty"`
-	Start            int64                     `json:"Start"`
-	Last             int64                     `json:"Last"`
-	UpdateCount      int64                     `json:"UpdateCount"`
-	NodeType         string                    `json:"NodeType,omitempty"`
-	LogStatus        string                    `json:"LogStatus,omitempty"`
+	UUID             string                       `json:"UUID,omitempty"`
+	LinkID           int64                        `json:"-"`
+	L3TrackingID     string                       `json:"-"`
+	LayersPath       string                       `json:"LayersPath,omitempty"`
+	Version          string                       `json:"Version,omitempty"`
+	Status           string                       `json:"Status,omitempty"`
+	FinishType       string                       `json:"FinishType,omitempty"`
+	Network          *SecurityAdvisorFlowLayer    `json:"Network,omitempty"`
+	Transport        *SecurityAdvisorFlowLayer    `json:"Transport,omitempty"`
+	Context          *SecurityAdvisorPeerContexts `json:"Context,omitempty"`
+	LastUpdateMetric *flow.FlowMetric             `json:"LastUpdateMetric,omitempty"`
+	Metric           *flow.FlowMetric             `json:"Metric,omitempty"`
+	Start            int64                        `json:"Start"`
+	Last             int64                        `json:"Last"`
+	UpdateCount      int64                        `json:"UpdateCount"`
+	NodeType         string                       `json:"NodeType,omitempty"`
+	LogStatus        string                       `json:"LogStatus,omitempty"`
 }
 
 // SecurityAdvisorFlowTransformer is a custom transformer for flows
@@ -129,13 +159,24 @@ func (ft *securityAdvisorFlowTransformer) getFinishType(f *flow.Flow) string {
 	return ""
 }
 
-func (ft *securityAdvisorFlowTransformer) getNetwork(f *flow.Flow) *SecurityAdvisorFlowLayer {
+func extractLegacyName(context *PeerContext) string {
+	if context != nil && context.Type == PeerTypePod && context.Name != "" {
+		return "0_0_" + context.Name + "_0"
+	}
+	return ""
+}
+
+func (ft *securityAdvisorFlowTransformer) getNetwork(f *flow.Flow, contexts *SecurityAdvisorPeerContexts) *SecurityAdvisorFlowLayer {
 	if f.Network == nil {
 		return nil
 	}
 
-	aName, _ := ft.resolver.IPToName(f.Network.A, f.NodeTID)
-	bName, _ := ft.resolver.IPToName(f.Network.B, f.NodeTID)
+	aName := ""
+	bName := ""
+	if contexts != nil {
+		aName = extractLegacyName(contexts.A)
+		bName = extractLegacyName(contexts.B)
+	}
 
 	return &SecurityAdvisorFlowLayer{
 		Protocol: f.Network.Protocol.String(),
@@ -143,6 +184,24 @@ func (ft *securityAdvisorFlowTransformer) getNetwork(f *flow.Flow) *SecurityAdvi
 		B:        f.Network.B,
 		AName:    aName,
 		BName:    bName,
+	}
+}
+
+func (ft *securityAdvisorFlowTransformer) getPeerContexts(f *flow.Flow) *SecurityAdvisorPeerContexts {
+	if f.Network == nil {
+		return nil
+	}
+
+	aContext, _ := ft.resolver.IPToContext(f.Network.A, f.NodeTID)
+	bContext, _ := ft.resolver.IPToContext(f.Network.B, f.NodeTID)
+
+	if aContext == nil && bContext == nil {
+		return nil
+	}
+
+	return &SecurityAdvisorPeerContexts{
+		A: aContext,
+		B: bContext,
 	}
 }
 
@@ -178,6 +237,8 @@ func (ft *securityAdvisorFlowTransformer) Transform(f *flow.Flow) interface{} {
 
 	nodeType, _ := ft.resolver.TIDToType(f.NodeTID)
 
+	peerContexts := ft.getPeerContexts(f)
+
 	return &SecurityAdvisorFlow{
 		UUID:             f.UUID,
 		LinkID:           ft.getLinkID(f),
@@ -186,7 +247,8 @@ func (ft *securityAdvisorFlowTransformer) Transform(f *flow.Flow) interface{} {
 		Version:          version,
 		Status:           status,
 		FinishType:       ft.getFinishType(f),
-		Network:          ft.getNetwork(f),
+		Network:          ft.getNetwork(f, peerContexts),
+		Context:          peerContexts,
 		Transport:        ft.getTransport(f),
 		LastUpdateMetric: f.LastUpdateMetric,
 		Metric:           f.Metric,

--- a/secadvisor/pkg/transform_test.go
+++ b/secadvisor/pkg/transform_test.go
@@ -209,9 +209,9 @@ func TestTransformShouldResolveRuncContainerNames(t *testing.T) {
 	assertEqual(t, "0_0_my-container-name-5bbc557665-h66vq_0", secAdvFlow.Network.AName)
 }
 
-func TestTransformShouldUseIPWhenCantFindContainerNames(t *testing.T) {
+func TestTransformShouldLeaveNameBlankWhenCantFindContainerNames(t *testing.T) {
 	transformer := getTestTransformerWithLocalTopology(t)
 	f := getRuncFlow()
 	secAdvFlow := transformer.Transform(f).(*SecurityAdvisorFlow)
-	assertEqual(t, "111.112.113.114", secAdvFlow.Network.BName)
+	assertEqual(t, "", secAdvFlow.Network.BName)
 }


### PR DESCRIPTION
Instead of packing information in the `Network.A_Name` string field, we introduce the following output format:

        {
          "Network": {
            "A": "172.17.0.13",
            "B": "8.8.8.8"
            "A_Name": "0_0_my-namespace/my-pod-name_0",
          },
          "Context": {
            "A": {
              "Type": "pod",
              "Name": "my-namespace/my-pod-name",
              "Set": "ReplicaSet:my-namespace/my-replicaset"
            }
          }

This allows for easier and safer addition of more enrichment information from the Skydive topology into the reported flows.

We add an IPToContext function to the resolves, which replaces the IPToName functionality.  Context is stored in a local cache per IP+TID.

Repeated Gremlin queries were extracted to gremlin_queries.go.

Note that for now the A_Name/B_Name fields are still kept as-is for backward compatibility.

