### PR TITLE
allinone: Register required handlers

### DIFF
--- a/allinone/main.go
+++ b/allinone/main.go
@@ -28,7 +28,8 @@ func main() {
 }
 
 func init() {
+	core.ManglerHandlers.Register("logstatus", secadvisor.NewMangleLogStatus, false)
 	core.EncoderHandlers.Register("secadvisor", secadvisor.NewEncode, false)
 	core.TransformerHandlers.Register("awsflowlogs", awsflowlogs.NewTransform, false)
-	core.TransformerHandlers.Register("vpclogs", secadvisor.NewTransform, false)
+	core.TransformerHandlers.Register("secadvisor", secadvisor.NewTransform, false)
 }


### PR DESCRIPTION
The logstatus ManglerHandler and the secadvisor TransformerHandler were not registered in `allinone`, and therefore the following errors were given when starting with ./allinone.yml.default:

    ERROR   core/main.go:45 Main    : Failed to initialize pipeline: mangle type logstatus not supported

and:

    ERROR   core/main.go:45 Main    : Failed to initialize pipeline: transform type secadvisor not supported

Generally I think we'd like all different handlers to be registered under `allinone`.