### PR TITLE
Makefile: Add fmt-check and fmt-fix targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ BUILD := \
 STATIC := \
 	allinone \
 
-TEST := \
-	secadvisor \
-
 .PHONY: all
 all:
 	for i in $(BUILD); do $(MAKE) -C $$i || exit; done
@@ -20,14 +17,8 @@ all:
 clean:
 	for i in $(BUILD); do $(MAKE) -C $$i clean || exit; done
 
-.PHONY: fmt
-fmt:
-	for i in $(BUILD); do $(MAKE) -C $$i fmt; done
-
-.PHONY: test
-test:
-	for i in $(TEST); do $(MAKE) -C $$i test || exit; done
-
 .PHONY: static
 static:
 	for i in $(STATIC); do $(MAKE) -C $$i static || exit; done
+
+include Makefile.dev

--- a/Makefile.conf
+++ b/Makefile.conf
@@ -1,10 +1,3 @@
-VERBOSE_FLAGS?=-v
-VERBOSE?=true
-ifeq ($(VERBOSE), false)
-  VERBOSE_FLAGS:=
-endif
-TIMEOUT?=1m
-
 all: EXTLDFLAGS:=
 static: EXTLDFLAGS:=-extldflags "-static"
 
@@ -21,14 +14,6 @@ $(PROG): $(SRCS)
 clean:
 	rm -rf $(PROG)
 
-.PHONY: test
-test: $(TESTS)
-	go test $(VERBOSE_FLAGS) -timeout ${TIMEOUT} ./...
-
 .PHONY: run
 run: all
 	./$(PROG) $(PROG).yml.default
-
-.PHONY: fmt
-fmt:
-	gofmt -w -s $$(find . -name "*.go")

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -1,0 +1,22 @@
+VERBOSE_FLAGS?=-v
+VERBOSE?=true
+ifeq ($(VERBOSE), false)
+  VERBOSE_FLAGS:=
+endif
+TIMEOUT?=1m
+
+.PHONY: test
+test: $(TESTS)
+	go test $(VERBOSE_FLAGS) -timeout ${TIMEOUT} ./...
+
+.PHONY: fmt-fix
+fmt-fix:
+	@echo "+ $@"
+	gofmt -w -s .
+
+.PHONY: fmt-check
+fmt-check:
+	@echo "+ $@"
+	@badfiles="$$(gofmt -l -s .)" && \
+		test -z "$$badfiles" || \
+		(echo "$$badfiles" && echo "+ please format Go code with 'make fmt-fix'" && /bin/false)

--- a/allinone/Makefile
+++ b/allinone/Makefile
@@ -4,3 +4,4 @@ SRCS := \
 	main.go \
 
 include ../Makefile.conf
+include ../Makefile.dev

--- a/awsflowlogs/Makefile
+++ b/awsflowlogs/Makefile
@@ -4,3 +4,4 @@ SRCS := \
 	main.go \
 
 include ../Makefile.conf
+include ../Makefile.dev

--- a/core/Makefile
+++ b/core/Makefile
@@ -19,9 +19,7 @@ SRCS := \
 all:
 	go build $(SRCS)
 
-.PHONY: fmt
-fmt:
-	gofmt -w -s *.go
-
 .PHONY: clean
-clean:
+clean: ;
+
+include ../Makefile.dev

--- a/dummy/Makefile
+++ b/dummy/Makefile
@@ -4,3 +4,4 @@ SRCS := \
 	main.go \
 
 include ../Makefile.conf
+include ../Makefile.dev

--- a/secadvisor/Makefile
+++ b/secadvisor/Makefile
@@ -4,3 +4,4 @@ SRCS := \
 	main.go \
 
 include ../Makefile.conf
+include ../Makefile.dev

--- a/vpclogs/Makefile
+++ b/vpclogs/Makefile
@@ -4,3 +4,4 @@ SRCS := \
 	main.go \
 
 include ../Makefile.conf
+include ../Makefile.dev


### PR DESCRIPTION
(following @hunchback's suggestion from #21)

`make fmt-check` will print out the names of source files that need to
be reformatted and exit with non-zero exitcode in case any file is not
correctly formatted.

`make fmt-fix` runs `gofmt -w -s .` to fix source code formatting.

The main Makefile now runs test, fmt-check, and fmt-fix on the entire
repo instead of folder-by-folder.  When running test or fmt-check it'll
give all the errors instead of just the first folder that fails.

