### PR TITLE
Makefile: Use go install to build binaries in standard location

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -1,18 +1,26 @@
-all: EXTLDFLAGS:=
-static: EXTLDFLAGS:=-extldflags "-static"
+VERBOSE_FLAGS?=-v
+VERBOSE?=true
+ifeq ($(VERBOSE), false)
+  VERBOSE_FLAGS:=
+endif
+TIMEOUT?=1m
 
-.PHONY: all static
-all static: $(PROG)
+STATIC_EXTLDFLAGS:='-extldflags=-static'
 
 .PHONY: all
-all: $(PROG)
+all: install
 
-$(PROG): $(SRCS)
-	go build -o $(PROG) -ldflags="${LDFLAGS} $(EXTLDFLAGS)" $(SRCS)
+.PHONY: install
+install:
+	go install -ldflags="$(LDFLAGS)" .
+
+.PHONY: static
+static:
+	go install -ldflags="$(LDFLAGS) $(STATIC_EXTLDFLAGS)" .
 
 .PHONY: clean
 clean:
-	rm -rf $(PROG)
+	go clean -i .
 
 .PHONY: run
 run: all

--- a/Makefile.dev
+++ b/Makefile.dev
@@ -6,7 +6,7 @@ endif
 TIMEOUT?=1m
 
 .PHONY: test
-test: $(TESTS)
+test:
 	go test $(VERBOSE_FLAGS) -timeout ${TIMEOUT} ./...
 
 .PHONY: fmt-fix

--- a/allinone/Makefile
+++ b/allinone/Makefile
@@ -1,7 +1,4 @@
 PROG := allinone
 
-SRCS := \
-	main.go \
-
 include ../Makefile.conf
 include ../Makefile.dev

--- a/awsflowlogs/Makefile
+++ b/awsflowlogs/Makefile
@@ -1,7 +1,4 @@
 PROG := awsflowlogs
 
-SRCS := \
-	main.go \
-
 include ../Makefile.conf
 include ../Makefile.dev

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,25 +1,2 @@
-SRCS := \
-	account.go \
-	classify.go \
-	compress.go \
-	encode.go \
-	filter.go \
-	pipeline.go \
-	main.go \
-	mangle.go \
-	store_buffered.go \
-	store_direct.go \
-	store_header.go \
-	subscriber.go \
-	transform.go \
-	write_s3.go \
-	write_stdout.go \
-
-.PHONY: all
-all:
-	go build $(SRCS)
-
-.PHONY: clean
-clean: ;
-
+include ../Makefile.conf
 include ../Makefile.dev

--- a/dummy/Makefile
+++ b/dummy/Makefile
@@ -1,7 +1,4 @@
 PROG := dummy
 
-SRCS := \
-	main.go \
-
 include ../Makefile.conf
 include ../Makefile.dev

--- a/secadvisor/Makefile
+++ b/secadvisor/Makefile
@@ -1,7 +1,4 @@
 PROG := secadvisor
 
-SRCS := \
-	main.go \
-
 include ../Makefile.conf
 include ../Makefile.dev

--- a/vpclogs/Makefile
+++ b/vpclogs/Makefile
@@ -1,7 +1,4 @@
 PROG := vpclogs
 
-SRCS := \
-	main.go \
-
 include ../Makefile.conf
 include ../Makefile.dev


### PR DESCRIPTION
Instead of building the flow-exporter binaries inside the source
directory, we use the `go install` tool to build binaries in
`$GOPATH/bin` (outside the source directory).

Cleaning is done with `go clean -i`.

The `SRCS` makefile variable is no longer needed.