### PR TITLE
secadvisor: Add subnet_autodiscovery classifier

### DIFF
--- a/allinone/main.go
+++ b/allinone/main.go
@@ -28,6 +28,7 @@ func main() {
 }
 
 func init() {
+	core.ClassifierHandlers.Register("subnet_autodiscovery", secadvisor.NewClassifySubnetWithAutoDiscovery, false)
 	core.ManglerHandlers.Register("logstatus", secadvisor.NewMangleLogStatus, false)
 	core.EncoderHandlers.Register("secadvisor", secadvisor.NewEncode, false)
 	core.TransformerHandlers.Register("awsflowlogs", awsflowlogs.NewTransform, false)

--- a/core/classify.go
+++ b/core/classify.go
@@ -90,10 +90,17 @@ func (fc *classify) isClusterIP(ip string) (bool, error) {
 	return false, nil
 }
 
-// NewClassifySubnet returns a new classify, based on the given cluster
-// net masks
+// NewClassifySubnet returns a new classify based on cluster net masks
+// from the global configuration
 func NewClassifySubnet(cfg *viper.Viper) (interface{}, error) {
 	clusterNetMasks := cfg.GetStringSlice(CfgRoot + "classify.cluster_net_masks")
+	return NewClassifySubnetFromList(clusterNetMasks)
+}
+
+// NewClassifySubnetFromList returns a new classify based on the given
+// cluster net masks
+func NewClassifySubnetFromList(clusterNetMasks []string) (interface{}, error) {
+	logging.GetLogger().Infof("Cluster net masks: %v", clusterNetMasks)
 	parsedNetMasks := make([]*net.IPNet, 0, len(clusterNetMasks))
 	for _, netMask := range clusterNetMasks {
 		_, sa, err := net.ParseCIDR(netMask)

--- a/secadvisor/main.go
+++ b/secadvisor/main.go
@@ -27,6 +27,7 @@ func main() {
 }
 
 func init() {
+	core.ClassifierHandlers.Register("subnet_autodiscovery", secadvisor.NewClassifySubnetWithAutoDiscovery, false)
 	core.ManglerHandlers.Register("logstatus", secadvisor.NewMangleLogStatus, false)
 	core.EncoderHandlers.Register("secadvisor", secadvisor.NewEncode, true)
 	core.TransformerHandlers.Register("secadvisor", secadvisor.NewTransform, false)

--- a/secadvisor/pkg/classify_autodiscovery.go
+++ b/secadvisor/pkg/classify_autodiscovery.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pkg
+
+import (
+	"github.com/spf13/viper"
+
+	"github.com/skydive-project/skydive-flow-exporter/core"
+	"github.com/skydive-project/skydive/api/client"
+	"github.com/skydive-project/skydive/logging"
+)
+
+// NewClassifySubnetWithAutoDiscovery creates a ClassifySubnet object with
+// additional discovery of Kubernetes cluster nodes IP netmasks.
+func NewClassifySubnetWithAutoDiscovery(cfg *viper.Viper) (interface{}, error) {
+	clusterNetMasks := cfg.GetStringSlice(core.CfgRoot + "classify.cluster_net_masks")
+	gremlinClient := client.NewGremlinQueryHelper(core.CfgAuthOpts(cfg))
+	nodesIPs, err := FindClusterNodesIPs(gremlinClient)
+	if err != nil {
+		return nil, err
+	}
+	nodesNetmasks := ConvertIPsToNetmasks(nodesIPs)
+	logging.GetLogger().Infof("Adding Kubenetes cluster nodes net masks: %v", nodesNetmasks)
+	clusterNetMasks = append(clusterNetMasks, nodesNetmasks...)
+	return core.NewClassifySubnetFromList(clusterNetMasks)
+}

--- a/secadvisor/pkg/cluster_ips.go
+++ b/secadvisor/pkg/cluster_ips.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pkg
+
+import (
+	"github.com/skydive-project/skydive/graffiti/graph"
+	g "github.com/skydive-project/skydive/gremlin"
+)
+
+// ConvertIPsToNetmasks converts a list of IPs to a list of single-host
+// netmasks which can be used for cluster netmasks.
+func ConvertIPsToNetmasks(ips []string) []string {
+	netmasks := []string{}
+	for _, ip := range ips {
+		netmasks = append(netmasks, ip+"/32")
+	}
+	return netmasks
+}
+
+// FindClusterNodesIPs returns the list of IP addresses of the Kubernetes
+// cluster nodes. External IPs are preferred, but if not found then internal
+// IPs are returned.
+func FindClusterNodesIPs(gremlinClient GremlinNodeGetter) ([]string, error) {
+	nodes, err := gremlinClient.GetNodes(g.G.V().Has("Manager", "k8s", "Type", "node"))
+	if err != nil {
+		return []string{}, err
+	}
+
+	ips := []string{}
+	for _, node := range nodes {
+		ip, err := extractNodeIP(node)
+		if err == nil && ip != "" {
+			ips = append(ips, ip)
+		}
+	}
+	return ips, nil
+}
+
+// Extract the first ExternalIP found, or, if none exists, the InternalIP
+// found; otherwise returns an empty string
+func extractNodeIP(node *graph.Node) (string, error) {
+	addressesObj, err := node.GetField("K8s.Extra.Status.Addresses")
+	if err != nil {
+		return "", err
+	}
+
+	addresses, ok := addressesObj.([]interface{})
+	if !ok {
+		return "", err
+	}
+
+	internalIP := ""
+	for _, addressObj := range addresses {
+		address, ok := addressObj.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		addrType, ok := address["Type"].(string)
+		if !ok {
+			continue
+		}
+		ip, ok := address["Address"].(string)
+		if !ok {
+			continue
+		}
+		switch addrType {
+		case "ExternalIP":
+			return ip, nil
+		case "InternalIP":
+			internalIP = ip
+		}
+	}
+	return internalIP, nil
+}

--- a/secadvisor/pkg/cluster_ips_test.go
+++ b/secadvisor/pkg/cluster_ips_test.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2019 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy ofthe License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specificlanguage governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pkg
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/skydive-project/skydive/graffiti/graph"
+)
+
+func newKubernetesNodesWithExternalIPsTopologyGraph(t *testing.T) *graph.Graph {
+	g := newGraph(t)
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Manager": "k8s",
+		"Type":    "node",
+		"Name":    "10.74.144.91",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"Status": map[string]interface{}{
+					"Addresses": []interface{}{
+						map[string]interface{}{
+							"Address": "10.74.144.91",
+							"Type":    "InternalIP",
+						},
+						map[string]interface{}{
+							"Address": "169.63.32.36",
+							"Type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"Address": "10.74.144.91",
+							"Type":    "Hostname",
+						},
+					},
+				},
+			},
+		},
+	})
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Manager": "k8s",
+		"Type":    "node",
+		"Name":    "10.74.144.75",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"Status": map[string]interface{}{
+					"Addresses": []interface{}{
+						map[string]interface{}{
+							"Address": "10.74.144.75",
+							"Type":    "InternalIP",
+						},
+						map[string]interface{}{
+							"Address": "169.63.32.43",
+							"Type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"Address": "10.74.144.75",
+							"Type":    "Hostname",
+						},
+					},
+				},
+			},
+		},
+	})
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Manager": "k8s",
+		"Type":    "node",
+		"Name":    "10.74.144.77",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"Status": map[string]interface{}{
+					"Addresses": []interface{}{
+						map[string]interface{}{
+							"Address": "10.74.144.77",
+							"Type":    "InternalIP",
+						},
+						map[string]interface{}{
+							"Address": "169.63.32.45",
+							"Type":    "ExternalIP",
+						},
+						map[string]interface{}{
+							"Address": "10.74.144.77",
+							"Type":    "Hostname",
+						},
+					},
+				},
+			},
+		},
+	})
+	return g
+}
+
+func newKubernetesNodesWithoutExternalIPsTopologyGraph(t *testing.T) *graph.Graph {
+	g := newGraph(t)
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Manager": "k8s",
+		"Type":    "node",
+		"Name":    "10.74.144.91",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"Status": map[string]interface{}{
+					"Addresses": []interface{}{
+						map[string]interface{}{
+							"Address": "10.74.144.91",
+							"Type":    "InternalIP",
+						},
+						map[string]interface{}{
+							"Address": "10.74.144.91",
+							"Type":    "Hostname",
+						},
+					},
+				},
+			},
+		},
+	})
+	g.NewNode(graph.GenID(), graph.Metadata{
+		"Manager": "k8s",
+		"Type":    "node",
+		"Name":    "10.74.144.75",
+		"K8s": map[string]interface{}{
+			"Extra": map[string]interface{}{
+				"Status": map[string]interface{}{
+					"Addresses": []interface{}{
+						map[string]interface{}{
+							"Address": "10.74.144.75",
+							"Type":    "InternalIP",
+						},
+						map[string]interface{}{
+							"Address": "10.74.144.75",
+							"Type":    "Hostname",
+						},
+					},
+				},
+			},
+		},
+	})
+	return g
+}
+
+func TestFindClusterNodesIpsShouldFindExternalIPs(t *testing.T) {
+	gremlinClient := newLocalGremlinQueryHelper(newKubernetesNodesWithExternalIPsTopologyGraph(t))
+	ips, err := FindClusterNodesIPs(gremlinClient)
+	if err != nil {
+		t.Fatalf("findClusterNodesIPs failed: %v", err)
+	}
+	sort.Sort(sort.StringSlice(ips))
+	expected := []string{"169.63.32.36", "169.63.32.43", "169.63.32.45"}
+	if !reflect.DeepEqual(expected, ips) {
+		t.Errorf("Expected: %+v, got: %+v", expected, ips)
+	}
+}
+
+func TestFindClusterNodesIpsShouldFindInternalIPsWhenThereAreNoExternalIPs(t *testing.T) {
+	gremlinClient := newLocalGremlinQueryHelper(newKubernetesNodesWithoutExternalIPsTopologyGraph(t))
+	ips, err := FindClusterNodesIPs(gremlinClient)
+	if err != nil {
+		t.Fatalf("findClusterNodesIPs failed: %v", err)
+	}
+	sort.Sort(sort.StringSlice(ips))
+	expected := []string{"10.74.144.75", "10.74.144.91"}
+	if !reflect.DeepEqual(expected, ips) {
+		t.Errorf("Expected: %+v, got: %+v", expected, ips)
+	}
+}
+
+func TestConvertIPsToNetmasks(t *testing.T) {
+	netmasks := ConvertIPsToNetmasks([]string{"1.2.3.4", "5.6.7.8"})
+	expected := []string{"1.2.3.4/32", "5.6.7.8/32"}
+	if !reflect.DeepEqual(expected, netmasks) {
+		t.Errorf("Expected: %+v, got: %+v", expected, netmasks)
+	}
+}

--- a/secadvisor/secadvisor.yml.default
+++ b/secadvisor/secadvisor.yml.default
@@ -17,6 +17,7 @@ pipeline:
     type: logstatus
   # classify flows into: internal, ingress, egress and other
   classify:
+    type: subnet_autodiscovery
     # list of internal cluster address ranges
     cluster_net_masks:
       - 10.0.0.0/8


### PR DESCRIPTION
The new `subnet_autodiscovery` classifier uses the cluster netmasks
given in the configuration (`pipeline.classify.cluster_net_masks`) and
adds all the Kubernetes cluster nodes' addresses (external IPs were
available, otherwise internal IPs).

The Kubernetes nodes IPs are taken using a Skydive topology query (the
Skydive analyzer is expected to pull all the configuration from
Kubernetes).

In order to use this classifier the user must set the following
configuration:

    pipeline:
      classify:
        type: subnet_autodiscovery
        cluster_net_masks:
          - 10.0.0.0/8
          ...

or set the `SKYDIVE_PIPELINE_CLASSIFY_TYPE=subnet_autodiscovery`
environment variable.

@hunchback , @sa-cloud : Please review.