### PR TITLE
Dockerfile: fix command-line arguments in ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG  BASE=ubuntu:19.04
 FROM $BASE
 ARG  ARCH=amd64
 RUN apt-get -y update \
-    && apt-get -y install libpcap0.8 \
+    && apt-get -y install ca-certificates libpcap0.8 \
     && rm -rf /var/lib/apt/lists/*
 COPY allinone.$ARCH /usr/bin/skydive-flow-exporter
 COPY allinone/allinone.yml.default /etc/skydive-flow-exporter.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get -y update \
     && rm -rf /var/lib/apt/lists/*
 COPY allinone.$ARCH /usr/bin/skydive-flow-exporter
 COPY allinone/allinone.yml.default /etc/skydive-flow-exporter.yml
-ENTRYPOINT ["/usr/bin/skydive-flow-exporter", "--conf", "/etc/skydive-flow-exporter.yml"]
+ENTRYPOINT ["/usr/bin/skydive-flow-exporter", "/etc/skydive-flow-exporter.yml"]


### PR DESCRIPTION
Currently running the skydive-flow-exporter docker container gives the
following error:

    $ docker run --rm -it skydive/skydive-flow-exporter:master
    2020-02-04T09:00:48.303Z        ERROR   core/main.go:34 Main ebc6cf5a29b8 Failed to initialize config: open --conf: no such file or directory

The skydive-flow-exporter executable receives only one command-line
argument which is the name of the YAML configuration file.