### PR TITLE
secadvisor: Remove illegal chars from legacy A_Name/B_Name fields

### DIFF
--- a/secadvisor/pkg/transform.go
+++ b/secadvisor/pkg/transform.go
@@ -19,6 +19,7 @@ package pkg
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	cache "github.com/pmylund/go-cache"
@@ -163,9 +164,19 @@ func (ft *securityAdvisorFlowTransformer) getFinishType(f *flow.Flow) string {
 	return ""
 }
 
+func cleanLegacyPeerName(name string) string {
+	replaceSpecialChar := func(r rune) rune {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			return r
+		}
+		return '-'
+	}
+	return strings.Map(replaceSpecialChar, name)
+}
+
 func extractLegacyName(context *PeerContext) string {
 	if context != nil && context.Type == PeerTypePod && context.Name != "" {
-		return "0_0_" + context.Name + "_0"
+		return "0_0_" + cleanLegacyPeerName(context.Name) + "_0"
 	}
 	return ""
 }

--- a/secadvisor/pkg/transform_test.go
+++ b/secadvisor/pkg/transform_test.go
@@ -163,8 +163,8 @@ func Test_Transform_basic_flow(t *testing.T) {
 	core.AssertEqualInt64(t, 1546338030000, secAdvFlow.Last)
 	core.AssertEqual(t, "fake_node_type", secAdvFlow.NodeType)
 	// Test legacy container names
-	core.AssertEqual(t, "0_0_one-namespace/fake-pod-one_0", secAdvFlow.Network.AName)
-	core.AssertEqual(t, "0_0_two-namespace/fake-pod-two_0", secAdvFlow.Network.BName)
+	core.AssertEqual(t, "0_0_one-namespace-fake-pod-one_0", secAdvFlow.Network.AName)
+	core.AssertEqual(t, "0_0_two-namespace-fake-pod-two_0", secAdvFlow.Network.BName)
 	// Test container context
 	core.AssertEqual(t, PeerTypePod, secAdvFlow.Context.A.Type)
 	core.AssertEqual(t, "one-namespace/fake-pod-one", secAdvFlow.Context.A.Name)
@@ -260,7 +260,7 @@ func TestTransformShouldResolveRuncContainerContext(t *testing.T) {
 	transformer.extendGremlin.populateExtendGremlin(f, transformer)
 	secAdvFlow := transformer.Transform(f).(*SecurityAdvisorFlow)
 	core.AssertEqual(t, "netns", secAdvFlow.NodeType)
-	core.AssertEqual(t, "0_0_kube-system/kubernetes-dashboard-7996b848f4-pmv4z_0", secAdvFlow.Network.AName) // Legacy field
+	core.AssertEqual(t, "0_0_kube-system-kubernetes-dashboard-7996b848f4-pmv4z_0", secAdvFlow.Network.AName) // Legacy field
 	core.AssertEqual(t, PeerTypePod, secAdvFlow.Context.A.Type)
 	core.AssertEqual(t, "kube-system/kubernetes-dashboard-7996b848f4-pmv4z", secAdvFlow.Context.A.Name)
 	core.AssertEqual(t, "ReplicaSet:kube-system/kubernetes-dashboard-7996b848f4", secAdvFlow.Context.A.Set)
@@ -281,4 +281,9 @@ func TestExtendGremlin(t *testing.T) {
 	// verify that extension fields were properly created
 	assertEqualExtend(t, "one-namespace/fake-pod-one", secAdvFlow.Extend, "CA_Name")
 	assertEqualExtend(t, "two-namespace/fake-pod-two", secAdvFlow.Extend, "CB_Name")
+}
+
+func TestCleanLegacyNameShouldRemoveSlashesAndUnderscores(t *testing.T) {
+	core.AssertEqual(t, "abc.123-GHI", cleanLegacyPeerName("abc.123-GHI"))
+	core.AssertEqual(t, "abc-123-GHI", cleanLegacyPeerName("abc_123/GHI"))
 }


### PR DESCRIPTION
The legacy peer name flow fields (Network.A_Name and Network.B_Name)
must be formatted as "0_0_<name>_0", where the name must consist of
`0-9A-Za-z.-` chars only.

This fix adds cleanup which reduces all other chars to a `-`.

@hunchback Please review.

@lebauce If all OK, please merge and then tag (and push) a `v0.1.2` tag.